### PR TITLE
Implement demo prerendering feature

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -468,6 +468,7 @@ typedef struct client_static_s {
         qboolean    paused;
         qboolean    seeking;
         qboolean    eof;
+		char		file_name[MAX_OSPATH];
     } demo;
 
 #if USE_CLIENT_GTV

--- a/src/client/demo.c
+++ b/src/client/demo.c
@@ -27,6 +27,8 @@ static byte     demo_buffer[MAX_PACKETLEN];
 static cvar_t   *cl_demosnaps;
 static cvar_t   *cl_demomsglen;
 static cvar_t   *cl_demowait;
+cvar_t   *cl_renderdemo;
+cvar_t   *cl_renderdemo_fps;
 
 // =========================================================================
 
@@ -730,6 +732,9 @@ static void CL_PlayDemo_f(void)
     CL_Disconnect(ERR_RECONNECT);
 
     cls.demo.playback = f;
+
+	Q_strlcpy(cls.demo.file_name, Cmd_Argv(1), sizeof(cls.demo.file_name));
+
     cls.state = ca_connected;
     Q_strlcpy(cls.servername, COM_SkipPath(name), sizeof(cls.servername));
     cls.serverAddress.type = NA_LOOPBACK;
@@ -1275,6 +1280,9 @@ void CL_InitDemos(void)
     cl_demosnaps = Cvar_Get("cl_demosnaps", "10", 0);
     cl_demomsglen = Cvar_Get("cl_demomsglen", va("%d", MAX_PACKETLEN_WRITABLE_DEFAULT), 0);
     cl_demowait = Cvar_Get("cl_demowait", "0", 0);
+
+	cl_renderdemo = Cvar_Get("cl_renderdemo", "0", CVAR_ARCHIVE);
+	cl_renderdemo_fps = Cvar_Get("cl_renderdemo_fps", "60", CVAR_ARCHIVE);
 
     Cmd_Register(c_demo);
     List_Init(&cls.demo.snapshots);

--- a/src/client/screen.c
+++ b/src/client/screen.c
@@ -92,6 +92,8 @@ static cvar_t   *ch_scale;
 static cvar_t   *ch_x;
 static cvar_t   *ch_y;
 
+extern cvar_t	*cl_renderdemo;
+
 #ifdef _DEBUG
 cvar_t      *scr_netgraph;
 cvar_t      *scr_timegraph;
@@ -2114,8 +2116,9 @@ static void SCR_DrawActive(void)
     // start with full screen HUD
     scr.hud_height = r_config.height;
     scr.hud_width = r_config.width;
-
-    SCR_DrawDemo();
+	
+	if (!cl_renderdemo->integer)
+		SCR_DrawDemo();
 
     SCR_CalcVrect();
 


### PR DESCRIPTION
Hand Merge/Recoded the Implement demo prerendering feature commit

Demo prerendering feature via `game`` and cl_renderdemo_fps. Playing a demo with cl_renderdemo 1 will essentially "render" a sequence of accumulated frames (according to pt_accumulation_rendering_framenum cvar) at the framerate of cl_renderdemo_fps to your game/screenshots folder (eg baseq2/screenshots) with demoname_framenumber syntax. This sequence of images can then be imported to video editor of your choice to be compiled to a movie. To capture sound you need to do a separate run without demo rendering enabled whilst maintaining same target framerate (so RTX off is recommended and framerate lock via r_maxfps should be used) and record the audio with external software of your choice.

pt_focus 1
Sets the distance to the focal plane for the Depth of Field effect.

pt_aperture 0.01
Controls the size of the camera aperture for the Depth of Field effect, in world units.

pt_freecam 0
Enables free floating camera when the game is paused. Default value is 1.

pt_dof
- 0 — always disabled
- 1 — enabled only in the photo mode (default)
- 2 — enabled in the photo mode and when the denoiser is disabled
- 3 — always enabled (_NOTE_: do not expect good image quality with the denoiser)

pt_aperture_angle
Sets the rotation angle of the camera aperture.

pt_aperture_type
Sets the type of the camera aperture. 0-2 means circular aperture, 3 or more specifies
the number of edges for a polygonal aperture.