### PR TITLE
Add trigger_reverb_preset

### DIFF
--- a/kmnac/game/g_fog.c
+++ b/kmnac/game/g_fog.c
@@ -27,6 +27,8 @@ void target_grfog_use(edict_t *self, edict_t *other, edict_t *activator);
 void SP_target_grfog(edict_t *self);
 void trigger_grfog_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf);
 void SP_trigger_grfog(edict_t *self);
+void trigger_reverb_preset_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf);
+void SP_trigger_reverb_preset(edict_t *self);
 
 /*
 //#ifdef KMQUAKE2_ENGINE_MOD

--- a/kmnac/game/g_func_decs.h
+++ b/kmnac/game/g_func_decs.h
@@ -1800,3 +1800,5 @@ extern qboolean ACEAI_FindEnemy ( edict_t * self ) ;
 extern void ACEAI_PickShortRangeGoal ( edict_t * self ) ;
 extern void ACEAI_PickLongRangeGoal ( edict_t * self ) ;
 extern void ACEAI_Think ( edict_t * self ) ;
+extern void trigger_reverb_preset_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf);
+extern void SP_trigger_reverb_preset(edict_t *self);

--- a/kmnac/game/g_func_list.h
+++ b/kmnac/game/g_func_list.h
@@ -1470,6 +1470,8 @@
 {"trigger_fog_use", (byte *)trigger_fog_use},
 {"SP_trigger_grfog", (byte *)SP_trigger_grfog},
 {"trigger_grfog_touch", (byte *)trigger_grfog_touch},
+{"SP_trigger_reverb_preset", (byte *)SP_trigger_reverb_preset },
+{"trigger_reverb_preset_touch", (byte *)trigger_reverb_preset_touch },
 {"SP_target_fog", (byte *)SP_target_fog},
 {"target_fog_use", (byte *)target_fog_use},
 {"SP_target_grfog", (byte *)SP_target_grfog},

--- a/kmnac/game/g_local.h
+++ b/kmnac/game/g_local.h
@@ -493,7 +493,22 @@ typedef struct
 	int         grFogDelay;
 	vec3_t      grFogColor;
 	int			grFogMode;
-
+	int			reverbpreset;
+	char        *reverb;
+	int         TriggerDelay;
+	char        *flDensity;
+	char        *flDiffusion;
+	char        *flGain;
+	char        *flGainHF;
+	char        *flDecayTime;
+	char        *flDecayHFRatio;
+	char        *flReflectionsGain;
+	char        *flReflectionsDelay;
+	char        *flLateReverbGain;
+	char        *flLateReverbDelay;
+	char        *flAirAbsorptionGainHF;
+	char        *flRoomRolloffFactor;
+	int     	iDecayHFLimit;
 } spawn_temp_t;
 
 
@@ -1987,6 +2002,22 @@ struct edict_s
 	int         grFogDelay;
 	vec3_t      grFogColor;
 	int			grFogMode;
+	int			reverbpreset;
+	char        *reverb;
+	int         TriggerDelay;
+	char        *flDensity;
+	char        *flDiffusion;
+	char        *flGain;
+	char        *flGainHF;
+	char        *flDecayTime;
+	char        *flDecayHFRatio;
+	char        *flReflectionsGain;
+	char        *flReflectionsDelay;
+	char        *flLateReverbGain;
+	char        *flLateReverbDelay;
+	char        *flAirAbsorptionGainHF;
+	char        *flRoomRolloffFactor;
+	int     	iDecayHFLimit;
 
 };
 

--- a/kmnac/game/g_save.c
+++ b/kmnac/game/g_save.c
@@ -284,6 +284,23 @@ field_t fields[] = {
 	{ "grFogDelay", STOFS(grFogDelay), F_INT, FFL_SPAWNTEMP },
 	{ "grFogMode", STOFS(grFogMode), F_INT, FFL_SPAWNTEMP },
 	{ "grFogColor", STOFS(grFogColor), F_VECTOR, FFL_SPAWNTEMP },
+	{ "reverb", STOFS(reverb), F_LSTRING, FFL_SPAWNTEMP },
+	{ "reverbpreset", STOFS(reverbpreset), F_INT, FFL_SPAWNTEMP },
+	{ "TriggerDelay", STOFS(TriggerDelay), F_INT, FFL_SPAWNTEMP },
+	{ "flDensity", STOFS(flDensity), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flDiffusion", STOFS(flDiffusion), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flGain", STOFS(flGain), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flGainHF", STOFS(flGainHF), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flDecayTime", STOFS(flDecayTime), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flDecayHFRatio", STOFS(flDecayHFRatio), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flReflectionsGain", STOFS(flReflectionsGain), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flReflectionsDelay", STOFS(flReflectionsDelay), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flLateReverbGain", STOFS(flLateReverbGain), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flLateReverbDelay", STOFS(flLateReverbDelay), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flAirAbsorptionGainHF", STOFS(flAirAbsorptionGainHF), F_LSTRING, FFL_SPAWNTEMP },
+	{ "flRoomRolloffFactor", STOFS(flRoomRolloffFactor), F_LSTRING, FFL_SPAWNTEMP },
+
+	{ "iDecayHFLimit", STOFS(iDecayHFLimit), F_INT, FFL_SPAWNTEMP },
 	{0, 0, 0, 0}
 
 };

--- a/kmnac/game/g_spawn.c
+++ b/kmnac/game/g_spawn.c
@@ -205,6 +205,7 @@ void SP_tremor_trigger_multiple (edict_t *self);
 void SP_trigger_bbox (edict_t *self);
 void SP_trigger_disguise (edict_t *self);
 void SP_trigger_grfog(edict_t *self);
+void SP_trigger_reverb_preset(edict_t *self);
 void SP_trigger_fog (edict_t *self);
 void SP_trigger_inside (edict_t *self);
 void SP_trigger_look (edict_t *self);
@@ -456,6 +457,7 @@ spawn_t	spawns[] = {
 // end Lazarus
 	{ "target_grfog", SP_target_grfog },
 	{ "trigger_grfog", SP_trigger_grfog },
+	{ "trigger_reverb_preset", SP_trigger_reverb_preset },
 
 	{NULL, NULL}
 };

--- a/kmnac/game/g_target.c
+++ b/kmnac/game/g_target.c
@@ -4533,3 +4533,49 @@ void SP_trigger_grfog(edict_t *self)
 	
 	
 }
+
+void trigger_reverb_preset_touch(edict_t *self, edict_t *other, cplane_t *plane, csurface_t *surf)
+{
+	if (self->spawnflags & 1)
+	{
+		stuffcmd(&g_edicts[1], va("s_reverb_set_preset %d\n", self->reverbpreset));
+		self->count--;
+		if (self->count == 0)
+		{
+			self->think = G_FreeEdict;
+			self->nextthink = level.time + FRAMETIME;
+		}
+	}
+	else
+	{
+	}
+}
+
+void SP_trigger_reverb_preset(edict_t *self)
+{
+	self->class_id = ENTITY_TRIGGER_REVERB_PRESET;
+
+	if ((!(self->spawnflags & 8)) || self->spawnflags & 4)
+	{
+		self->spawnflags |= 1;
+	}
+
+	self->reverbpreset = st.reverbpreset;
+		
+	self->TriggerDelay = (float)st.TriggerDelay * 1000.0f;
+
+	self->reverb = gi.TagMalloc(64 + 1, TAG_LEVEL);
+	strcpy(self->reverb, st.reverb);
+
+	if (!VectorCompare(self->s.angles, vec3_origin))
+		G_SetMovedir(self->s.angles, self->movedir);
+
+	self->solid = SOLID_TRIGGER;
+	self->movetype = MOVETYPE_NONE;
+	gi.setmodel(self, self->model);
+	self->svflags = SVF_NOCLIENT;
+
+	self->touch = trigger_reverb_preset_touch;
+
+
+}

--- a/src/client/sound/main.c
+++ b/src/client/sound/main.c
@@ -66,7 +66,7 @@ cvar_t		*s_reverb_preset_autopick;
 cvar_t		*s_reverb;
 cvar_t		*s_voiceinput;
 cvar_t		*s_voiceinput_volume;
-
+cvar_t		*s_reverb_set_preset;
 cvar_t      *s_ambient;
 #ifdef _DEBUG
 cvar_t      *s_show;
@@ -169,7 +169,26 @@ static void reverb_changed(cvar_t *self)
 
 	if (s_reverb_preset->integer > 112)
 		s_reverb_preset->integer = 112;
+
 	SetReverb(s_reverb_preset->integer, 1);
+}
+
+extern int TriggerReverbOverrideReverb;
+extern int TriggerReverbOverride;
+extern int TriggerReverbOverrideNeeded;
+static void reverb_set_preset_changed(cvar_t *self)
+{
+	int selfValue = self->integer;
+
+	if (selfValue < 0)
+		selfValue = 0;
+
+	if (selfValue > 112)
+		selfValue = 112;
+		
+	TriggerReverbOverride = 1;
+	TriggerReverbOverrideNeeded = 1;
+	TriggerReverbOverrideReverb = selfValue;
 }
 
 static void voiceinputvolume_changed(cvar_t *self)
@@ -200,7 +219,7 @@ void S_Init(void)
 	s_doppler = Cvar_Get("s_doppler", "1", CVAR_ARCHIVE);
 	s_occlusion = Cvar_Get("s_occlusion", "1", CVAR_ARCHIVE);
 	s_occlusion_strength = Cvar_Get("s_occlusion_strength", "1", CVAR_ARCHIVE);
-	s_reverb_preset = Cvar_Get("s_reverb_preset", "0", CVAR_ARCHIVE);
+	s_reverb_preset = Cvar_Get("s_reverb_preset", "7", CVAR_ARCHIVE);
 	s_reverb_preset->changed = reverb_changed;
 	s_reverb = Cvar_Get("s_reverb", "1", CVAR_ARCHIVE);
 	s_reverb_preset_autopick = Cvar_Get("s_reverb_preset_autopick", "1", CVAR_ARCHIVE);
@@ -210,6 +229,10 @@ void S_Init(void)
 	s_underwater = Cvar_Get("s_underwater", "1", CVAR_ARCHIVE);
 	s_underwater_gain_hf = Cvar_Get("s_underwater_gain_hf", "0.25", CVAR_ARCHIVE);
     s_ambient = Cvar_Get("s_ambient", "1", 0);
+
+	s_reverb_set_preset = Cvar_Get("s_reverb_set_preset", "7", CVAR_SERVERINFO);
+	s_reverb_set_preset->changed = reverb_set_preset_changed;
+
 #ifdef _DEBUG
     s_show = Cvar_Get("s_show", "0", 0);
 #endif


### PR DESCRIPTION
Added trigger_reverb_preset to the FGD and Client and Game
Modified AL_Spatialize to use exp2 instead of linear math.
//
// TRIGGER_REVERB_PRESET
@SolidClass base(Appearflags, Targetname, Angles1, Count1) color(255 0 0) = trigger_reverb_preset : "reverb preset field"
[
    spawnflags(Flags) =
    [
        8 : "8>Start Off" : 0
    ]
    reverbpreset(choices) : "Preset> Pre defined reverb settings" : 0 =
    [
	0 : "GENERIC"
	1 : "PADDEDCELL"
	2 : "ROOM"
	3 : "BATHROOM"
	4 : "LIVINGROOM"
	5 : "STONEROOM"
	6 : "AUDITORIUM"
	7 : "CONCERTHALL"
	8 : "CAVE"
	9 : "ARENA"
	10 : "HANGAR"
	11 : "CARPETEDHALLWAY"
	12 : "HALLWAY"
	13 : "STONECORRIDOR"
	14 : "ALLEY"
	15 : "FOREST"
	16 : "CITY"
	17 : "MOUNTAINS"
	18 : "QUARRY"
	19 : "PLAIN"
	20 : "PARKINGLOT"
	21 : "SEWERPIPE"
	22 : "UNDERWATER"
	23 : "DRUGGED"
	24 : "DIZZY"
	25 : "PSYCHOTIC"
	26 : "CASTLE_SMALLROOM"
	27 : "CASTLE_SHORTPASSAGE"
	28 : "CASTLE_MEDIUMROOM"
	29 : "CASTLE_LARGEROOM"
	30 : "CASTLE_LONGPASSAGE"
	31 : "CASTLE_HALL"
	32 : "CASTLE_CUPBOARD"
	33 : "CASTLE_COURTYARD"
	34 : "CASTLE_ALCOVE"
	35 : "FACTORY_SMALLROOM"
	36 : "FACTORY_SHORTPASSAGE"
	37 : "FACTORY_MEDIUMROOM"
	38 : "FACTORY_LARGEROOM"
	39 : "FACTORY_LONGPASSAGE"
	40 : "FACTORY_HALL"
	41 : "FACTORY_CUPBOARD"
	42 : "FACTORY_COURTYARD"
	43 : "FACTORY_ALCOVE"
	44 : "ICEPALACE_SMALLROOM"
	45 : "ICEPALACE_SHORTPASSAGE"
	46 : "ICEPALACE_MEDIUMROOM"
	47 : "ICEPALACE_LARGEROOM"
	48 : "ICEPALACE_LONGPASSAGE"
	49 : "ICEPALACE_HALL"
	50 : "ICEPALACE_CUPBOARD"
	51 : "ICEPALACE_COURTYARD"
	52 : "ICEPALACE_ALCOVE"
	53 : "SPACESTATION_SMALLROOM"
	54 : "SPACESTATION_SHORTPASSAGE"
	55 : "SPACESTATION_MEDIUMROOM"
	56 : "SPACESTATION_LARGEROOM"
	57 : "SPACESTATION_LONGPASSAGE"
	58 : "SPACESTATION_HALL"
	59 : "SPACESTATION_CUPBOARD"
	60 : "SPACESTATION_ALCOVE"
	61 : "WOODEN_SMALLROOM"
	62 : "WOODEN_SHORTPASSAGE"
	63 : "WOODEN_MEDIUMROOM"
	64 : "WOODEN_LARGEROOM"
	65 : "WOODEN_LONGPASSAGE"
	66 : "WOODEN_HALL"
	67 : "WOODEN_CUPBOARD"
	68 : "WOODEN_COURTYARD"
	69 : "WOODEN_ALCOVE"
	70 : "SPORT_EMPTYSTADIUM"
	71 : "SPORT_SQUASHCOURT"
	72 : "SPORT_SMALLSWIMMINGPOOL"
	73 : "SPORT_LARGESWIMMINGPOOL"
	74 : "SPORT_GYMNASIUM"
	75 : "SPORT_FULLSTADIUM"
	76 : "SPORT_STADIUMTANNOY"
	77 : "PREFAB_WORKSHOP"
	78 : "PREFAB_SCHOOLROOM"
	79 : "PREFAB_PRACTISEROOM"
	80 : "PREFAB_OUTHOUSE"
	81 : "PREFAB_CARAVAN"
	82 : "DOME_TOMB"
	83 : "PIPE_SMALL"
	84 : "DOME_SAINTPAULS"
	85 : "PIPE_LONGTHIN"
	86 : "PIPE_LARGE"
	87 : "PIPE_RESONANT"
	88 : "OUTDOORS_BACKYARD"
	89 : "OUTDOORS_ROLLINGPLAINS"
	90 : "OUTDOORS_DEEPCANYON"
	91 : "OUTDOORS_CREEK"
	92 : "OUTDOORS_VALLEY"
	93 : "MOOD_HEAVEN"
	94 : "MOOD_HELL"
	95 : "MOOD_MEMORY"
	96 : "DRIVING_COMMENTATOR"
	97 : "DRIVING_PITGARAGE"
	98 : "DRIVING_INCAR_RACER"
	99 : "DRIVING_INCAR_SPORTS"
	100 : "DRIVING_INCAR_LUXURY"
	101 : "DRIVING_FULLGRANDSTAND"
	102 : "DRIVING_EMPTYGRANDSTAND"
	103 : "DRIVING_TUNNEL"
	104 : "CITY_STREETS"
	105 : "CITY_SUBWAY"
	106 : "CITY_MUSEUM"
	107 : "CITY_LIBRARY"
	108 : "CITY_UNDERPASS"
	109 : "CITY_ABANDONED"
	110 : "DUSTYROOM"
	111 : "CHAPEL"
	112 : "SMALLWATERROOM"
    ]
    TriggerDelay(integer) : "Delay>ramp time (sec)" : 1
    reverb(string) : "Reverb>Info" : "Enter Description"
]